### PR TITLE
feat(performance): add __slots__ to Result class

### DIFF
--- a/benchmark/time_result.py
+++ b/benchmark/time_result.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from timeit import timeit
+
+from meiga import Error, Failure, Result, Success
+
+
+class NoSuchKey(Error):
+    ...
+
+
+class TypeMismatch(Error):
+    ...
+
+
+def string_from_key(
+    dictionary: dict, key: str
+) -> Result[str, NoSuchKey | TypeMismatch]:
+    if key not in dictionary.keys():
+        return Failure(NoSuchKey())
+
+    value = dictionary[key]
+    if not isinstance(value, str):
+        return Failure(TypeMismatch())
+
+    return Success(value)
+
+
+dictionary = {
+    "key1": "value",
+    "key2": 2,
+    "key3": "value",
+    "key4": 2,
+    "key5": "value",
+    "key6": 2,
+    "key7": "value",
+    "key8": 2,
+    "key9": "value",
+    "key10": 2,
+    "key11": "value",
+    "key12": 2,
+}
+
+time_success = timeit(lambda: string_from_key(dictionary=dictionary, key="key1"))
+print(f"time when success: {time_success}")
+
+time_failure_no_such_key = timeit(
+    lambda: string_from_key(dictionary=dictionary, key="invalid_key")
+)
+print(f"time when failure (no such key): {time_failure_no_such_key}")
+
+time_failure_type_missmatch = timeit(
+    lambda: string_from_key(dictionary=dictionary, key="key2")
+)
+print(f"time when failure (type missmatch): {time_failure_type_missmatch}")

--- a/meiga/result.py
+++ b/meiga/result.py
@@ -16,6 +16,7 @@ TEF = TypeVar("TEF")  # External Failure Type
 
 class Result(Generic[TS, TF]):
     __id__ = "__meiga_result_identifier__"
+    __slots__ = ("_value_success", "_value_failure", "_is_success")
 
     def __init__(
         self,


### PR DESCRIPTION
Benchmark code:

```python
from __future__ import annotations

from timeit import timeit

from meiga import Error, Failure, Result, Success


class NoSuchKey(Error):
    ...


class TypeMismatch(Error):
    ...


def string_from_key(
    dictionary: dict, key: str
) -> Result[str, NoSuchKey | TypeMismatch]:
    if key not in dictionary.keys():
        return Failure(NoSuchKey())

    value = dictionary[key]
    if not isinstance(value, str):
        return Failure(TypeMismatch())

    return Success(value)


dictionary = {
    "key1": "value",
    "key2": 2,
    "key3": "value",
    "key4": 2,
    "key5": "value",
    "key6": 2,
    "key7": "value",
    "key8": 2,
    "key9": "value",
    "key10": 2,
    "key11": "value",
    "key12": 2,
}

time_success = timeit(lambda: string_from_key(dictionary=dictionary, key="key1"))
print(f"time when success: {time_success}")

time_failure_no_such_key = timeit(
    lambda: string_from_key(dictionary=dictionary, key="invalid_key")
)
print(f"time when failure (no such key): {time_failure_no_such_key}")

time_failure_type_missmatch = timeit(
    lambda: string_from_key(dictionary=dictionary, key="key2")
)
print(f"time when failure (type missmatch): {time_failure_type_missmatch}")

```

Result without slots:

```console
$ python benchmark/time_result.py
time when success: 0.5478533749992494
time when failure (no such key): 0.5760475420102011
time when failure (type missmatch): 0.6188615420251153
```

Result with slots:

```console
$ python benchmark/time_result.py
time when success: 0.5113824579748325
time when failure (no such key): 0.550075833016308
time when failure (type missmatch): 0.5880016250011977
```

## Improvements

Improvement when success: ~7% faster (x1.071318279412337)
Improvement when failure (no such key): ~5% faster (x1.047214779190496)
Improvement failure (type missmatch): ~5% faster (x1.052482707039891)


