### PR TITLE
Feature/add called from info on waiting for early return exception

### DIFF
--- a/meiga/failures.py
+++ b/meiga/failures.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING
+import inspect
+from typing import TYPE_CHECKING, Union
 
 from meiga.error import Error
 
@@ -8,15 +9,21 @@ if TYPE_CHECKING:
 
 class WaitingForEarlyReturn(Error):
     result: "AnyResult"
+    called_from: Union[str, None]
 
     def __init__(self, result: "AnyResult") -> None:
         self.result = result
+        try:
+            self.called_from = inspect.stack()[2][3]
+        except:  # noqa
+            self.called_from = None
         Exception.__init__(self)
 
     def __str__(self) -> str:
+        function = f" ({self.called_from})" if self.called_from else ""
         return (
             f"This exception wraps the following result -> {self.result}"
-            f"\nIf you want to handle this error and return a Failure, please use early_return decorator on your function."
+            f"\nIf you want to handle this error and return a Failure, please use early_return decorator on your function{function}."
             f"\nMore info about how to use unwrap_or_return in combination with @early_return decorator on https://alice-biometrics.github.io/meiga/usage/result/#unwrap_or_return"
         )
 

--- a/meiga/failures.py
+++ b/meiga/failures.py
@@ -14,7 +14,9 @@ class WaitingForEarlyReturn(Error):
     def __init__(self, result: "AnyResult") -> None:
         self.result = result
         try:
-            self.called_from = inspect.stack()[2][3]
+            stack = inspect.stack()[2]
+            filename = stack.filename.split("/")[-1]
+            self.called_from = f"{stack[3]} on {filename}"
         except:  # noqa
             self.called_from = None
         Exception.__init__(self)

--- a/tests/unit/test_early_return.py
+++ b/tests/unit/test_early_return.py
@@ -6,110 +6,107 @@ from meiga.decorators import UnexpectedDecorationOrderError
 
 
 @pytest.mark.unit
-def test_should_return_a_success_result_with_meiga_decorator():
-    @early_return
-    def decorated_method():
-        return isSuccess
+class TestEarlyReturn:
+    def should_return_a_success_result_with_meiga_decorator(self):
+        @early_return
+        def decorated_method():
+            return isSuccess
 
-    result = decorated_method()
+        result = decorated_method()
 
-    assert_success(result)
+        assert_success(result)
 
+    def should_return_a_failure_result_with_meiga_decorator(self):
+        @early_return
+        def decorated_method():
+            return isFailure
 
-@pytest.mark.unit
-def test_should_return_a_failure_result_with_meiga_decorator():
-    @early_return
-    def decorated_method():
-        return isFailure
+        result = decorated_method()
 
-    result = decorated_method()
+        assert_failure(result)
 
-    assert_failure(result)
+    def should_return_a_failure_result_with_meiga_decorator_when_raise_an_error(self):
+        @early_return
+        def decorated_method():
+            raise Error()
 
+        result = decorated_method()
 
-@pytest.mark.unit
-def test_should_return_a_failure_result_with_meiga_decorator_when_raise_an_error():
-    @early_return
-    def decorated_method():
-        raise Error()
+        assert_failure(result, value_is_instance_of=Error)
 
-    result = decorated_method()
+    def should_return_a_failure_result_with_meiga_decorator_when_raise_an_error_subclass(
+        self,
+    ):
+        class MyError(Error):
+            def __init__(self, message):
+                self.message = message
 
-    assert_failure(result, value_is_instance_of=Error)
-
-
-@pytest.mark.unit
-def test_should_return_a_failure_result_with_meiga_decorator_when_raise_an_error_subclass():
-    class MyError(Error):
-        def __init__(self, message):
-            self.message = message
-
-    @early_return
-    def decorated_method():
-        raise MyError("message")
-
-    result = decorated_method()
-
-    assert_failure(result, value_is_instance_of=MyError)
-
-
-@pytest.mark.unit
-def test_should_return_a_failure_result_with_meiga_decorator_and_inner_function_when_raise_an_error_subclass():
-    class MyError(Error):
-        def __init__(self, message):
-            self.message = message
-
-    @early_return
-    def decorated_method():
-        def inner():
+        @early_return
+        def decorated_method():
             raise MyError("message")
 
-        inner()
+        result = decorated_method()
 
-    result = decorated_method()
+        assert_failure(result, value_is_instance_of=MyError)
 
-    assert_failure(result, value_is_instance_of=MyError)
+    def should_return_a_failure_result_with_meiga_decorator_and_inner_function_when_raise_an_error_subclass(
+        self,
+    ):
+        class MyError(Error):
+            def __init__(self, message):
+                self.message = message
 
-
-@pytest.mark.unit
-def test_should_return_a_success_result_with_meiga_decorator_and_static_function_right_order():
-    class MyClass:
-        @staticmethod
         @early_return
-        def decorated_method() -> BoolResult:
-            return isSuccess
+        def decorated_method():
+            def inner():
+                raise MyError("message")
 
-    result = MyClass.decorated_method()
-    assert_success(result)
+            inner()
 
+        result = decorated_method()
 
-@pytest.mark.unit
-def test_should_return_a_unexpected_decorator_order_failure_result_with_meiga_decorator_and_static_method():
-    class MyClass:
-        @early_return
-        @staticmethod
-        def decorated_method() -> BoolResult:
-            return isSuccess
+        assert_failure(result, value_is_instance_of=MyError)
 
-    result = MyClass.decorated_method()
-    assert_failure(result, value_is_instance_of=UnexpectedDecorationOrderError)
-    assert (
-        result.value.message
-        == "meiga decorators must be declared after a @staticmethod, @classmethod"
-    )
+    def should_return_a_success_result_with_meiga_decorator_and_static_function_right_order(
+        self,
+    ):
+        class MyClass:
+            @staticmethod
+            @early_return
+            def decorated_method() -> BoolResult:
+                return isSuccess
 
+        result = MyClass.decorated_method()
+        assert_success(result)
 
-@pytest.mark.unit
-def test_should_return_a_unexpected_decorator_order_failure_result_with_meiga_decorator_and_class_method():
-    class MyClass:
-        @early_return
-        @classmethod
-        def decorated_method(cls) -> BoolResult:
-            return isSuccess
+    def should_return_a_unexpected_decorator_order_failure_result_with_meiga_decorator_and_static_method(
+        self,
+    ):
+        class MyClass:
+            @early_return
+            @staticmethod
+            def decorated_method() -> BoolResult:
+                return isSuccess
 
-    result = MyClass.decorated_method()
-    assert_failure(result, value_is_instance_of=UnexpectedDecorationOrderError)
-    assert (
-        result.value.message
-        == "meiga decorators must be declared after a @staticmethod, @classmethod"
-    )
+        result = MyClass.decorated_method()
+        assert_failure(result, value_is_instance_of=UnexpectedDecorationOrderError)
+        assert (
+            result.value.message
+            == "meiga decorators must be declared after a @staticmethod, @classmethod"
+        )
+
+    def should_return_a_unexpected_decorator_order_failure_result_with_meiga_decorator_and_class_method(
+        self,
+    ):
+        class MyClass:
+            @early_return
+            @classmethod
+            def decorated_method(cls) -> BoolResult:
+                return isSuccess
+
+        result = MyClass.decorated_method()
+        assert_failure(result, value_is_instance_of=UnexpectedDecorationOrderError)
+        assert (
+            result.value.message
+            == "meiga decorators must be declared after a @staticmethod, @classmethod"
+        )

--- a/tests/unit/test_waiting_for_early_return.py
+++ b/tests/unit/test_waiting_for_early_return.py
@@ -7,7 +7,7 @@ from meiga.on_failure_exception import OnFailureException
 def expected_error(value: str) -> str:
     return (
         f"This exception wraps the following result -> Result[status: failure | value: {value}]"
-        f"\nIf you want to handle this error and return a Failure, please use early_return decorator on your function."
+        f"\nIf you want to handle this error and return a Failure, please use early_return decorator on your function (pytest_pyfunc_call)."
         f"\nMore info about how to use unwrap_or_return in combination with @early_return decorator on https://alice-biometrics.github.io/meiga/usage/result/#unwrap_or_return"
     )
 

--- a/tests/unit/test_waiting_for_early_return.py
+++ b/tests/unit/test_waiting_for_early_return.py
@@ -1,15 +1,26 @@
+import re
+from typing import Union
+
 import pytest
 
-from meiga import Error, Result, WaitingForEarlyReturn
+from meiga import AnyResult, Error, Failure, Result, WaitingForEarlyReturn, isSuccess
 from meiga.on_failure_exception import OnFailureException
 
 
-def expected_error(value: str) -> str:
-    return (
+def expected_error(
+    value: str, called_from: Union[str | None] = None, escape: bool = False
+) -> str:
+    called_from = f" ({called_from})" if called_from else ""
+
+    text = (
         f"This exception wraps the following result -> Result[status: failure | value: {value}]"
-        f"\nIf you want to handle this error and return a Failure, please use early_return decorator on your function (pytest_pyfunc_call)."
+        f"\nIf you want to handle this error and return a Failure, please use early_return decorator on your function{called_from}."
         f"\nMore info about how to use unwrap_or_return in combination with @early_return decorator on https://alice-biometrics.github.io/meiga/usage/result/#unwrap_or_return"
     )
+    if escape:
+        return re.escape(text)  # necessary to match on pytest.raises contextmanager
+
+    return text
 
 
 @pytest.mark.unit
@@ -19,7 +30,9 @@ class TestWaitingForEarlyReturn:
 
         exception = WaitingForEarlyReturn(result)
 
-        assert expected_error("Error") == str(exception)
+        assert expected_error(
+            "Error", called_from="pytest_pyfunc_call on python.py"
+        ) == str(exception)
 
     def should_str_as_expected_an_exception(self):
         wrapped_exception = ValueError("Something went wrong")
@@ -27,7 +40,9 @@ class TestWaitingForEarlyReturn:
 
         exception = WaitingForEarlyReturn(result)
 
-        assert expected_error(wrapped_exception.__repr__()) == str(exception)
+        assert expected_error(
+            wrapped_exception.__repr__(), called_from="pytest_pyfunc_call on python.py"
+        ) == str(exception)
 
     def should_be_compatible_with_older_version_and_expect_st_as_expected_an_exception(
         self,
@@ -37,4 +52,39 @@ class TestWaitingForEarlyReturn:
 
         exception = OnFailureException(result)
 
-        assert expected_error(wrapped_exception.__repr__()) == str(exception)
+        assert expected_error(
+            wrapped_exception.__repr__(), called_from="pytest_pyfunc_call on python.py"
+        ) == str(exception)
+
+    def should_log_hint_when_called_from_function_and_not_early_return(self):
+        def inner_function() -> AnyResult:
+            result = Failure(Error())
+            result.unwrap_or_return()
+            return isSuccess
+
+        with pytest.raises(
+            WaitingForEarlyReturn,
+            match=expected_error(
+                "Error",
+                called_from="inner_function on test_waiting_for_early_return.py",
+                escape=True,
+            ),
+        ):
+            inner_function()
+
+    def should_log_hint_when_called_from_class_function_and_not_early_return(self):
+        class MyClass:
+            def execute(self) -> AnyResult:
+                result = Failure(Error())
+                result.unwrap_or_return()
+                return isSuccess
+
+        with pytest.raises(
+            WaitingForEarlyReturn,
+            match=expected_error(
+                "Error",
+                called_from="execute on test_waiting_for_early_return.py",
+                escape=True,
+            ),
+        ):
+            MyClass().execute()

--- a/tests/unit/test_waiting_for_early_return.py
+++ b/tests/unit/test_waiting_for_early_return.py
@@ -8,7 +8,7 @@ from meiga.on_failure_exception import OnFailureException
 
 
 def expected_error(
-    value: str, called_from: Union[str | None] = None, escape: bool = False
+    value: str, called_from: Union[str, None] = None, escape: bool = False
 ) -> str:
     called_from = f" ({called_from})" if called_from else ""
 


### PR DESCRIPTION
### Before:

**If you want to handle this error and return a Failure, please use early_return decorator on your function.**

### Now

**If you want to handle this error and return a Failure, please use early_return decorator on your function** `(foo in your_python_script.py)`